### PR TITLE
Some changes that need testing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile 'com.android.support:design:25.0.0'
     compile 'com.android.support:support-v4:25.0.0'
     compile 'com.android.support:recyclerview-v7:25.0.0'
-    compile 'com.mcxiaoke.volley:library:1.0.19'
+    compile 'com.android.volley:volley:1.0.0'
     compile 'org.ini4j:ini4j:0.5.4'
     compile 'commons-io:commons-io:2.5'
     compile 'com.melnykov:floatingactionbutton:1.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Ignore warnings caused by ini4j referencing non Android-runtime classes
+-dontwarn java.beans.*


### PR DESCRIPTION
As I don't have a device that is supported by EFIDroid and has the neccessary OTA files online for the app to show anything, I was not able to test if commit https://github.com/efidroid/android_app_efidroidmanager/commit/f3b24a3b88d0f9c02eeeccd175701bcaacf6f562 breaks any of the 3rd party libraries thoroughly. It builds and installs just fine though, navigating through the different categories in the navdrawer also doesn't cause problems. Commit https://github.com/efidroid/android_app_efidroidmanager/commit/2f45e88f3dafef31c714901723051c1a6d38f3eb just switches from the current deprecated mirror of the volley library to the official version.