### PR TITLE
Update OSUpdateProgressServiceTask.java

### DIFF
--- a/app/src/main/java/org/efidroid/efidroidmanager/tasks/OSUpdateProgressServiceTask.java
+++ b/app/src/main/java/org/efidroid/efidroidmanager/tasks/OSUpdateProgressServiceTask.java
@@ -129,7 +129,7 @@ public class OSUpdateProgressServiceTask extends ProgressServiceTask {
                             try {
                                 long size = partition.getSize();
 
-                                if (partition.getPartitionName().equals("firmware")) {
+                                if ((partition.getPartitionName().equals("firmware")) || (partition.getPartitionName().equals("firmware-modem"))) {
                                     FSTabEntry fsTabEntry = deviceInfo.getFSTab().getEntryByName(partition.getPartitionName());
                                     if (fsTabEntry == null)
                                         throw new Exception("Can't find " + partition.getPartitionName() + "in fstab.multiboot");


### PR DESCRIPTION
without this commit the manager app does not make a proper image of my vfat modem partition.

unpatched: firmware-modem.img: data

patched: firmware-modem.img: DOS/MBR boot sector, code offset 0x3c+2, OEM-ID "MSDOS5.0", sectors/cluster 32, root entries 512, Media descriptor 0xf8, sectors/FAT 17, sectors/track 63, heads 255, sectors 131072 (volumes > 32 MB) , serial number 0xbc614e, unlabeled, FAT (16 bit)